### PR TITLE
disable virtual keyboard

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -2,10 +2,14 @@
  * Disable Gestures 2021
  *
  * A GNOME extension that disables built-in gestures. Useful for kiosks and touch screen apps.
- * 
+ *
  */
 
 /* exported init */
+
+const KeyboardUI = imports.ui.keyboard;
+
+let _originalLastDeviceIsTouchscreen;
 
 class Extension {
   enable () {
@@ -15,6 +19,9 @@ class Extension {
     }
     global.display.connect('notify::focus-window', disableUnmaximizeGesture)
     global.display.connect('in-fullscreen-changed', disableUnmaximizeGesture)
+
+    _originalLastDeviceIsTouchscreen = KeyboardUI.KeyboardManager.prototype._lastDeviceIsTouchscreen;
+    KeyboardUI.KeyboardManager.prototype._lastDeviceIsTouchscreen = false;
   }
 
   disable () {
@@ -24,6 +31,9 @@ class Extension {
     }
     global.display.connect('notify::focus-window', enableUnmaximizeGesture)
     global.display.connect('in-fullscreen-changed', enableUnmaximizeGesture)
+
+    KeyboardUI.KeyboardManager.prototype._lastDeviceIsTouchscreen = _originalLastDeviceIsTouchscreen;
+    _originalLastDeviceIsTouchscreen = null;
   }
 }
 


### PR DESCRIPTION
Digitális billenyűzet letiltása azért, hogy a touchscreen újracsatlakoztatása után se lehessen azt gesture-el elhőhozni. A kód innen van: https://github.com/lxylxy123456/cariboublocker/blob/master/42/extension.js



Youtrack:
https://youtrack.techteamer.com/issue/BUGMBHKIOS-206/MBH-Digitalis-Zona-Miskolci-kapszula-kezdo-kepernyon-megjeleno-billentyuzet-2023.02.08.#focus=Comments-4-101383.0-0